### PR TITLE
configure: explicitly disable HAVE_TERMINFO on z/OS

### DIFF
--- a/stable-patches/configure.ac.patch
+++ b/stable-patches/configure.ac.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index e56c10a..cc87b05 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -190,9 +190,16 @@ LIBS="$LIBS $TERMLIBS"
+ 
+ # Check for terminfo vs termcap.
+ AC_MSG_CHECKING(for terminfo)
+-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
++case `uname -s` in
++OS/390)
++  AC_MSG_RESULT([no (explicitly disabled on z/OS)])
++  ;;
++*)
++  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+ #include <curses.h>
+ #include <term.h>]], [[setupterm("",0,0); tigetflag(""); tigetnum(""); tigetstr("")]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_TERMINFO)],[AC_MSG_RESULT(no)])
++  ;;
++esac
+ 
+ fi
+ 


### PR DESCRIPTION
Fixes the paging issue seen when paging up